### PR TITLE
OM-50425: Only use the node cache for a single round. (#313)

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,5 +1,5 @@
-FROM turbonomic/kubeturbo:6.4dev
-COPY kubeturbo.debug ${APP_ROOT}/bin/kubeturbo
+FROM turbonomic/kubeturbo:6.4.0
+COPY kubeturbo.debug /opt/turbonomic/bin/kubeturbo
 ADD dlv /usr/local/bin/dlv
 EXPOSE 40000
 ENTRYPOINT ["/usr/local/bin/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "exec", "/opt/turbonomic/bin/kubeturbo", "--", "--turboconfig=/etc/kubeturbo/turbo.config", "--v=2", "--kubelet-https=true", "--kubelet-port=10250"]

--- a/pkg/discovery/dtofactory/node_entity_dto_builder.go
+++ b/pkg/discovery/dtofactory/node_entity_dto_builder.go
@@ -65,6 +65,9 @@ func (builder *nodeEntityDTOBuilder) BuildEntityDTOs(nodes []*api.Node) ([]*prot
 		displayName := node.Name
 		entityDTOBuilder.DisplayName(displayName)
 		nodeActive := util.NodeIsReady(node)
+		if !nodeActive {
+			glog.Warningf("the NodeIsReady marked node %s as inactive", node.Name)
+		}
 
 		// compute and constraint commodities sold.
 		commoditiesSold, err := builder.getNodeCommoditiesSold(node)
@@ -100,6 +103,7 @@ func (builder *nodeEntityDTOBuilder) BuildEntityDTOs(nodes []*api.Node) ([]*prot
 		cacheUsedMetric := metrics.GenerateEntityStateMetricUID(metrics.NodeType, util.NodeKeyFunc(node), "NodeCacheUsed")
 		present, _ := builder.metricsSink.GetMetric(cacheUsedMetric)
 		if present != nil {
+			glog.Errorf("We have used the cached data, so the node %s appeared to be flaky", node)
 			nodeActive = false
 		}
 


### PR DESCRIPTION
* OM-50425: Only use the node cache for a single round.

Work around the issue whereas discovered node will be discovered, but its information
will be in-accessible using the API calls. In that case, we will reuse the data from
the last known good state forever.

Unit tests pass.

* OM-50425: Only use the node cache for a single round.

Work around the issue whereas discovered node will be discovered, but its information
will be in-accessible using the API calls. In that case, we will reuse the data from
the last known good state forever.

Unit tests passed.

* Fix the cache cleaning policy

* Clean up the code and fix a few things

* Fix stuff and add logs

* I think I found it. The metricsSink is there forever, and we don't clean it

* Improve the error message

* Another diagnostic message

* Another diagnostic message

* Another message and a fix for debug Docker file

* Rework the fix. Clear master sink

* Rework the fix. Clear master sink

* Rework the fix. Clear master sink